### PR TITLE
[1] - Search and Display Organization's Repo Data (REVISED)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,10 +30,12 @@ function App() {
           `${BASE_URL}/orgs/${searchValue}/repos`
         );
         setRepos(response.data);
+        if (response.data.length === 0)
+          setErrorMessage("Organization is private");
       }
     } catch (err) {
       setRepos([]);
-      setErrorMessage(err.response.data.message);
+      setErrorMessage("Organization not found");
       console.error(err);
     }
   };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,70 @@
 import { useState } from "react";
+import axios from "axios";
 import "./App.css";
 
+const BASE_URL = "https://api.github.com";
+
 function App() {
+  const [repos, setRepos] = useState([]);
+  const [searchValue, setSearchValue] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  /**
+   * Sets the search value state to the value within the input
+   * @param {*} e
+   */
+  const handleSearchChange = (e) => {
+    setSearchValue(e.target.value);
+  };
+
+  /**
+   * Sends a get request to github api to retrieve repo data for that organization
+   * @param {*} e
+   */
+  const handleFormSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMessage("");
+    try {
+      if (searchValue) {
+        const response = await axios.get(
+          `${BASE_URL}/orgs/${searchValue}/repos`
+        );
+        setRepos(response.data);
+      }
+    } catch (err) {
+      setRepos([]);
+      setErrorMessage(err.response.data.message);
+      console.error(err);
+    }
+  };
+
   return (
-    <div>
+    <div className="text-center py-5">
       <h1 className="text-2xl">GitHub Organization Explorer</h1>
+      <form onSubmit={handleFormSubmit}>
+        <input
+          type="text"
+          value={searchValue}
+          onChange={handleSearchChange}
+          className="border-2"
+        />
+        <button className="border-2">Search</button>
+        {errorMessage && <p className="text-red-500">{errorMessage}</p>}
+      </form>
+      <div>
+        {repos.map((repo, i) => {
+          return (
+            <div key={i} className="p-5 border-2 w-7/12 mx-auto">
+              <h1 className="text-xl underline">{repo.name}</h1>
+              <p>{repo.language}</p>
+              <p>{repo.description}</p>
+              <p>Star Count: {repo.stargazers_count}</p>
+              <p>Fork Count: {repo.forks_count}</p>
+              <p>Date Created: {repo.created_at}</p>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -92,7 +92,6 @@ audio,
 video {
   margin: 0;
   padding: 0;
-  border: 0;
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;


### PR DESCRIPTION
This PR serves the purpose of implementing the GitHub organization search functionality and displaying a simple list of that organization's repositories.

Features Include:
- Search input for users to query GitHub Organizations
- Search button for users to request given organization's repo data
- Error handling for missing search value, private repos, and unfound organizations
- Organization's repo data displayed including repo name, language, description, star count, fork count, and date created.

Current State of App:
![search-and-display-data](https://user-images.githubusercontent.com/95318530/223870781-28973310-c8d4-4eb8-83e6-ba68d98fce49.gif)